### PR TITLE
feat: configured linting rules for testing-library and import/order 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,12 +14,28 @@
     "import/order": [
       "error",
       {
-        "groups": ["builtin", "external", "internal"],
+        "groups": [
+          ["builtin", "external"],
+          ["internal", "parent", "sibling"],
+          ["index", "object", "type"]
+        ],
         "pathGroups": [
           {
             "pattern": "react",
             "group": "external",
             "position": "before"
+          },
+          {
+            "pattern": "@/components/**",
+            "group": "internal"
+          },
+          {
+            "pattern": "@/lib/**",
+            "group": "internal"
+          },
+          {
+            "pattern": "@/types/**",
+            "group": "type"
           }
         ],
         "pathGroupsExcludedImportTypes": ["react"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,35 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"],
-  "plugins": ["@emotion"],
+  "plugins": ["@emotion", "testing-library", "jest-dom"],
+  "extends": [
+    "next/core-web-vitals",
+    "prettier",
+    "plugin:testing-library/react",
+    "plugin:jest-dom/recommended"
+  ],
   "rules": {
     "@emotion/jsx-import": "error",
     "@emotion/no-vanilla": "error",
     "@emotion/import-from-emotion": "error",
-    "@emotion/styled-import": "error"
+    "@emotion/styled-import": "error",
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal"],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["react"],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
+
+import MenuIcon from '@mui/icons-material/Menu'
 import AppBar from '@mui/material/AppBar'
 import Box from '@mui/material/Box'
-import Toolbar from '@mui/material/Toolbar'
-import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
-import MenuIcon from '@mui/icons-material/Menu'
+import Toolbar from '@mui/material/Toolbar'
+import Typography from '@mui/material/Typography'
 import Link from 'next/link'
 
 export default function TopBar() {

--- a/components/common/AddToCart/AddToCart.stories.tsx
+++ b/components/common/AddToCart/AddToCart.stories.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
+
 import { ComponentStory, ComponentMeta } from '@storybook/react'
+
 import AddToCart from './AddToCart'
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+
 export default {
   title: 'Common/AddToCart',
   component: AddToCart,
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+
   argTypes: {
     backgroundColor: { control: 'color' },
   },
@@ -14,7 +16,7 @@ export default {
 const Template: ComponentStory<typeof AddToCart> = (args) => <AddToCart {...args} />
 
 export const Test1 = Template.bind({})
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
+
 Test1.args = {
   primary: true,
   label: 'Button',

--- a/components/common/KiboImage/KiboImage.stories.tsx
+++ b/components/common/KiboImage/KiboImage.stories.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import KiboImage from './KiboImage'
 import Logo from '@/public/kibo_logo.png'
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+import KiboImage from './KiboImage'
+
 export default {
   title: 'Common/KiboImage',
   component: KiboImage,
@@ -14,7 +14,6 @@ export default {
 const Template: ComponentStory<typeof KiboImage> = (args) => <KiboImage {...args} />
 
 export const Common = Template.bind({})
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
 Common.args = {
   src: Logo,
   alt: 'test-alt-text',

--- a/components/common/KiboImage/KiboImage.stories.tsx
+++ b/components/common/KiboImage/KiboImage.stories.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import Logo from '@/public/kibo_logo.png'
-
 import KiboImage from './KiboImage'
+import Logo from '@/public/kibo_logo.png'
 
 export default {
   title: 'Common/KiboImage',

--- a/components/common/KiboLogo/KiboLogo.stories.tsx
+++ b/components/common/KiboLogo/KiboLogo.stories.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import KiboLogo from './KiboLogo'
 import Logo from '@/public/kibo_logo.png'
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+import KiboLogo from './KiboLogo'
+
 export default {
   title: 'Common/KiboLogo',
   component: KiboLogo,
@@ -14,7 +14,7 @@ export default {
 const Template: ComponentStory<typeof KiboLogo> = (args) => <KiboLogo {...args} />
 
 export const Common = Template.bind({})
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
+
 Common.args = {
   logo: Logo,
   alt: 'kibo logo',

--- a/components/common/KiboLogo/KiboLogo.stories.tsx
+++ b/components/common/KiboLogo/KiboLogo.stories.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
-import Logo from '@/public/kibo_logo.png'
-
 import KiboLogo from './KiboLogo'
+import Logo from '@/public/kibo_logo.png'
 
 export default {
   title: 'Common/KiboLogo',

--- a/components/common/Price/Price.stories.tsx
+++ b/components/common/Price/Price.stories.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
+
 import { ComponentStory, ComponentMeta } from '@storybook/react'
+
 import Price from './Price'
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+
 export default {
   title: 'Common/Price',
   component: Price,
@@ -14,7 +16,6 @@ export default {
 const Template: ComponentStory<typeof Price> = (args) => <Price {...args} />
 
 export const priceOnly = Template.bind({})
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
 priceOnly.args = {
   price: '$120.00',
 }

--- a/components/core/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/components/core/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+
 import { ComponentStory, ComponentMeta } from '@storybook/react'
+
 import KiboBreadcrumbs from './Breadcrumbs'
 
 const breadcrumbList = [
@@ -17,7 +19,6 @@ const breadcrumbList = [
   },
 ]
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: 'Core/Breadcrumbs',
   component: KiboBreadcrumbs,
@@ -26,7 +27,6 @@ export default {
 const Template: ComponentStory<typeof KiboBreadcrumbs> = (args) => <KiboBreadcrumbs {...args} />
 
 export const common = Template.bind({})
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
 common.args = {
   breadcrumbs: breadcrumbList,
   separator: '|',

--- a/components/core/Breadcrumbs/Breadcrumbs.tsx
+++ b/components/core/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import Breadcrumbs from '@mui/material/Breadcrumbs'
+
 import { Link } from '@mui/material'
+import Breadcrumbs from '@mui/material/Breadcrumbs'
 
 export type Breadcrumb = {
   text: string

--- a/components/page-templates/ProductDetailTemplate.tsx
+++ b/components/page-templates/ProductDetailTemplate.tsx
@@ -1,9 +1,11 @@
+import React, { useCallback, useState } from 'react'
+
 import Add from '@mui/icons-material/Add'
 import { Box, Grid, Rating, Button, Radio, RadioGroup, FormControlLabel } from '@mui/material'
-import Link from 'next/link'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React, { useCallback, useState } from 'react'
+
 import FlexBox from '@/components/FlexBox'
 
 const ProductDetailTemplate = ({ product }: any) => {

--- a/components/page-templates/ProductListingTemplate.tsx
+++ b/components/page-templates/ProductListingTemplate.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import ProductList from '../product/ProductList'
 
 const ProductListingTemplate = (props: any) => {

--- a/components/product/ProductCard/ProductCard.spec.js
+++ b/components/product/ProductCard/ProductCard.spec.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { render, screen } from '@testing-library/react'
 
+import '@testing-library/jest-dom'
 import ProductCard from './ProductCard'
 
 it('Renders Product Card', () => {

--- a/components/product/ProductCard/ProductCard.spec.js
+++ b/components/product/ProductCard/ProductCard.spec.js
@@ -1,5 +1,7 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+
+import { render, screen } from '@testing-library/react'
+
 import ProductCard from './ProductCard'
 
 it('Renders Product Card', () => {
@@ -9,7 +11,7 @@ it('Renders Product Card', () => {
     price: '$9.99',
     title: 'This is a product',
   }
-  const { getByText } = render(<ProductCard {...props} />)
+  render(<ProductCard {...props} />)
 
-  expect(getByText(props.price)).toBeTruthy()
+  expect(screen.getByText(props.price)).toBeInTheDocument()
 })

--- a/components/product/ProductCard/ProductCard.stories.tsx
+++ b/components/product/ProductCard/ProductCard.stories.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
+
 import { ComponentStory, ComponentMeta } from '@storybook/react'
+
 import ProductCard from './ProductCard'
 import type { ProductCardProps } from './ProductCard'
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+
 export default {
   title: 'Product/ProductCard',
   component: ProductCard,
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {
     backgroundColor: { control: 'color' },
   },
@@ -15,7 +16,6 @@ export default {
 const Template: ComponentStory<typeof ProductCard> = (args) => <ProductCard {...args} />
 
 export const Common = Template.bind({})
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
 Common.args = {
   image: `https://cdn-tp3.mozu.com/24645-37138/cms/37138/files/42d958c7-94d3-46be-812a-488601cf0c04?max=155&_mzcb=_1618890579000`,
   link: '/product/test-123',
@@ -24,7 +24,6 @@ Common.args = {
 }
 
 export const AddToCard = Template.bind({})
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
 Common.args = {
   image: `https://cdn-tp3.mozu.com/24645-37138/cms/37138/files/42d958c7-94d3-46be-812a-488601cf0c04?max=155&_mzcb=_1618890579000`,
   link: '/product/test-123',

--- a/components/product/ProductCard/ProductCard.stories.tsx
+++ b/components/product/ProductCard/ProductCard.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import ProductCard from './ProductCard'
+
 import type { ProductCardProps } from './ProductCard'
 
 export default {

--- a/components/product/ProductCard/ProductCard.tsx
+++ b/components/product/ProductCard/ProductCard.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
+
 import { Card, Box } from '@mui/material'
-import FlexBox from '@/components/FlexBox'
 import { styled } from '@mui/material/styles'
-import Link from 'next/link'
 import Image from 'next/image'
+import Link from 'next/link'
+
+import FlexBox from '@/components/FlexBox'
 
 export interface ProductCardProps {
   price: string

--- a/components/product/ProductList/ProductList.tsx
+++ b/components/product/ProductList/ProductList.tsx
@@ -1,8 +1,10 @@
-import FlexBox from 'components/FlexBox'
-import { Grid, Pagination, Card } from '@mui/material'
 import React from 'react'
+
+import { Grid, Pagination, Card } from '@mui/material'
 import Image from 'next/image'
 import Link from 'next/link'
+
+import FlexBox from 'components/FlexBox'
 
 const selectProducts = (items: any = []): Array<any> => {
   return items.map((product: any) => {

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,4 +1,5 @@
 import { setGlobalConfig } from '@storybook/testing-react'
+
 import * as globalStorybookConfig from './.storybook/preview'
 
 setGlobalConfig(globalStorybookConfig)

--- a/lib/api/handlers/graphql.ts
+++ b/lib/api/handlers/graphql.ts
@@ -1,5 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+
 import { fetcher } from '../util'
+
 export default async function graphQLHandler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const { query, variables } = req.body

--- a/lib/api/handlers/graphql.ts
+++ b/lib/api/handlers/graphql.ts
@@ -1,6 +1,6 @@
-import type { NextApiRequest, NextApiResponse } from 'next'
-
 import { fetcher } from '../util'
+
+import type { NextApiRequest, NextApiResponse } from 'next'
 
 export default async function graphQLHandler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/lib/api/handlers/search.ts
+++ b/lib/api/handlers/search.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+
 import { productSearch } from '../operations'
 export default async function searchHandler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/lib/api/handlers/search.ts
+++ b/lib/api/handlers/search.ts
@@ -1,6 +1,7 @@
+import { productSearch } from '../operations'
+
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-import { productSearch } from '../operations'
 export default async function searchHandler(req: NextApiRequest, res: NextApiResponse) {
   try {
     // get variables

--- a/lib/api/operations/get-product-search.ts
+++ b/lib/api/operations/get-product-search.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from 'next'
-
 import { fetcher } from '@/lib/api/util'
 import { searchProductsQuery } from '@/lib/gql/queries/product-search'
+
+import type { NextApiRequest, NextApiResponse } from 'next'
 
 function getFacetValueFilter(categoryCode: any, filters: Array<string> = []) {
   let facetValueFilter = ''

--- a/lib/api/operations/get-product-search.ts
+++ b/lib/api/operations/get-product-search.ts
@@ -1,5 +1,6 @@
-import { fetcher } from '@/lib/api/util'
 import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { fetcher } from '@/lib/api/util'
 import { searchProductsQuery } from '@/lib/gql/queries/product-search'
 
 function getFacetValueFilter(categoryCode: any, filters: Array<string> = []) {

--- a/lib/api/util/api-auth-client.ts
+++ b/lib/api/util/api-auth-client.ts
@@ -1,6 +1,7 @@
 import { APIAuthClient, AppAuthTicket, ShopperAuthClient } from '@kibocommerce/graphql-client'
-import { getApiConfig } from './config-helpers'
 import vercelFetch from '@vercel/fetch'
+
+import { getApiConfig } from './config-helpers'
 
 const fetch = vercelFetch()
 let authTicket: AppAuthTicket | undefined

--- a/lib/api/util/fetch-gql.ts
+++ b/lib/api/util/fetch-gql.ts
@@ -1,6 +1,8 @@
 import vercelFetch from '@vercel/fetch'
-import { getGraphqlUrl } from './config-helpers'
+
 import { apiAuthClient } from './api-auth-client'
+import { getGraphqlUrl } from './config-helpers'
+
 const fetch = vercelFetch()
 
 const fetcher = async ({ query, variables }: any) => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react'
-import Head from 'next/head'
-import { AppProps } from 'next/app'
-import { ThemeProvider } from '@mui/material/styles'
-import CssBaseline from '@mui/material/CssBaseline'
+
 import { CacheProvider, EmotionCache } from '@emotion/react'
-import theme from '../styles/theme'
-import createEmotionCache from '../lib/createEmotionCache'
-import TopBar from '../components/TopBar'
-import { Hydrate, QueryClient, QueryClientProvider } from 'react-query'
+import CssBaseline from '@mui/material/CssBaseline'
+import { ThemeProvider } from '@mui/material/styles'
 import { appWithTranslation } from 'next-i18next'
+import { AppProps } from 'next/app'
+import Head from 'next/head'
+import { Hydrate, QueryClient, QueryClientProvider } from 'react-query'
+
+import TopBar from '../components/TopBar'
+import createEmotionCache from '../lib/createEmotionCache'
+import theme from '../styles/theme'
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache()

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
+
 // eslint-disable-next-line @next/next/no-document-import-in-page
-import Document, { Html, Head, Main, NextScript } from 'next/document'
 import createEmotionServer from '@emotion/server/create-instance'
-import theme from '../styles/theme'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
 import createEmotionCache from '../lib/createEmotionCache'
+import theme from '../styles/theme'
 
 export default class MyDocument extends Document {
   render() {
@@ -52,7 +54,7 @@ MyDocument.getInitialProps = async (ctx) => {
   // 3. app.render
   // 4. page.render
 
-  const originalRenderPage = ctx.renderPage
+  const view = ctx.renderPage
 
   // You can consider sharing the same emotion cache between all the SSR requests to speed up performance.
   // However, be aware that it can have global side effects.
@@ -60,7 +62,7 @@ MyDocument.getInitialProps = async (ctx) => {
   const { extractCriticalToChunks } = createEmotionServer(cache)
 
   ctx.renderPage = () =>
-    originalRenderPage({
+    view({
       // eslint-disable-next-line react/display-name
       enhanceApp: (App: any) => (props) => <App emotionCache={cache} {...props} />,
     })

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -1,3 +1,9 @@
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
+import { useQuery } from 'react-query'
+
+import { CartTemplate } from '@/components/page-templates'
+
 import type {
   NextPage,
   GetStaticPathsContext,
@@ -5,11 +11,6 @@ import type {
   InferGetStaticPropsType,
   GetServerSidePropsContext,
 } from 'next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useRouter } from 'next/router'
-import { useQuery } from 'react-query'
-
-import { CartTemplate } from '@/components/page-templates'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { locale } = context

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -5,10 +5,11 @@ import type {
   InferGetStaticPropsType,
   GetServerSidePropsContext,
 } from 'next'
-import { useQuery } from 'react-query'
-import { useRouter } from 'next/router'
-import { CartTemplate } from '@/components/page-templates'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
+import { useQuery } from 'react-query'
+
+import { CartTemplate } from '@/components/page-templates'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { locale } = context

--- a/pages/category/[categoryCode].tsx
+++ b/pages/category/[categoryCode].tsx
@@ -1,3 +1,10 @@
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
+import { useQuery } from 'react-query'
+
+import { ProductListingTemplate } from '@/components/page-templates'
+import { productSearch } from '@/lib/api/operations'
+
 import type {
   NextPage,
   GetStaticPathsContext,
@@ -5,12 +12,6 @@ import type {
   InferGetStaticPropsType,
   GetServerSidePropsContext,
 } from 'next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useRouter } from 'next/router'
-import { useQuery } from 'react-query'
-
-import { ProductListingTemplate } from '@/components/page-templates'
-import { productSearch } from '@/lib/api/operations'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { locale } = context

--- a/pages/category/[categoryCode].tsx
+++ b/pages/category/[categoryCode].tsx
@@ -5,12 +5,12 @@ import type {
   InferGetStaticPropsType,
   GetServerSidePropsContext,
 } from 'next'
-
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
 import { useQuery } from 'react-query'
+
 import { ProductListingTemplate } from '@/components/page-templates'
 import { productSearch } from '@/lib/api/operations'
-import { useRouter } from 'next/router'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { locale } = context

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,10 @@
+import Head from 'next/head'
+import Image from 'next/image'
+
+import Buton from '../components/buton'
+import styles from '../styles/Home.module.css'
+import AddToCart from '@/components/common/AddToCart/AddToCart'
+
 import type {
   NextPage,
   GetStaticPathsContext,
@@ -5,13 +12,6 @@ import type {
   InferGetStaticPropsType,
   GetServerSidePropsContext,
 } from 'next'
-import Head from 'next/head'
-import Image from 'next/image'
-
-import AddToCart from '@/components/common/AddToCart/AddToCart'
-
-import Buton from '../components/buton'
-import styles from '../styles/Home.module.css'
 
 const Home: NextPage = () => {
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,9 +7,12 @@ import type {
 } from 'next'
 import Head from 'next/head'
 import Image from 'next/image'
-import styles from '../styles/Home.module.css'
-import Buton from '../components/buton'
+
 import AddToCart from '@/components/common/AddToCart/AddToCart'
+
+import Buton from '../components/buton'
+import styles from '../styles/Home.module.css'
+
 const Home: NextPage = () => {
   return (
     <div className={styles.container}>

--- a/pages/product/[productCode].tsx
+++ b/pages/product/[productCode].tsx
@@ -1,3 +1,9 @@
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
+
+import { ProductDetailTemplate } from '@/components/page-templates'
+import getProduct from '@/lib/api/operations/get-product'
+
 import type {
   NextPage,
   GetStaticPathsContext,
@@ -5,11 +11,6 @@ import type {
   InferGetStaticPropsType,
   GetServerSidePropsContext,
 } from 'next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useRouter } from 'next/router'
-
-import { ProductDetailTemplate } from '@/components/page-templates'
-import getProduct from '@/lib/api/operations/get-product'
 
 export async function getStaticProps(context: GetStaticPropsContext) {
   const { params } = context

--- a/pages/product/[productCode].tsx
+++ b/pages/product/[productCode].tsx
@@ -5,10 +5,11 @@ import type {
   InferGetStaticPropsType,
   GetServerSidePropsContext,
 } from 'next'
-import getProduct from '@/lib/api/operations/get-product'
-import { ProductDetailTemplate } from '@/components/page-templates'
-import { useRouter } from 'next/router'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
+
+import { ProductDetailTemplate } from '@/components/page-templates'
+import getProduct from '@/lib/api/operations/get-product'
 
 export async function getStaticProps(context: GetStaticPropsContext) {
   const { params } = context

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,10 +1,3 @@
-import type {
-  NextPage,
-  GetStaticPathsContext,
-  GetStaticPropsContext,
-  InferGetStaticPropsType,
-  GetServerSidePropsContext,
-} from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useRouter } from 'next/router'
@@ -12,6 +5,14 @@ import { useQuery } from 'react-query'
 
 import { ProductListingTemplate } from '@/components/page-templates'
 import { productSearch } from '@/lib/api/operations/'
+
+import type {
+  NextPage,
+  GetStaticPathsContext,
+  GetStaticPropsContext,
+  InferGetStaticPropsType,
+  GetServerSidePropsContext,
+} from 'next'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const response = await productSearch(context.query)

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -5,12 +5,13 @@ import type {
   InferGetStaticPropsType,
   GetServerSidePropsContext,
 } from 'next'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
 import { useQuery } from 'react-query'
+
 import { ProductListingTemplate } from '@/components/page-templates'
 import { productSearch } from '@/lib/api/operations/'
-import { useRouter } from 'next/router'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useTranslation } from 'next-i18next'
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const response = await productSearch(context.query)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,13 +15,11 @@
     "jsx": "preserve",
     "incremental": true,
     "baseUrl": ".",
-    "paths": {      
-        "@/*": [
-          "./*"
-      ],
-      "@/lib/*": [
-        "lib/*"
-    ],
+    "paths": {
+      "@/*": ["./*"],
+      "@/lib/*": ["lib/*"],
+      "@/components/*": ["components/*"],
+      "@/types/*": ["types/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
reated PR for fixing linting issues
1. Created below import/order eslint rules
   import builting types
   // space
   import thirdpary types
   // space
   import internal types

   all the groups will be sorted

2. configured  below eslint plugins
   "plugin:testing-library/react",
   "plugin:jest-dom/recommended"

   and resolved linting issues like
    Error: Avoid destructuring queries from `render` result, use `screen.getByText` instead // testing-library/prefer-screen-queries
    Error: Prefer .toBeInTheDocument() for asserting DOM node existence	// jest-dom/prefer-in-document
    Error: `originalRenderPage` is not a recommended name for `render` returned value. 
    Instead, you should destructure it, or name it using one of: `view`, or `utils`  testing-library/render-result-naming-convention

3. Removed unwanted comments from stories.tsx
